### PR TITLE
Restore donation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated adm
 
 Pull requests and issues are welcome. Feel free to submit improvements or report problems on GitHub.
 
+## Author
+
+Costin Botez - [Buy me a coffee](https://www.buymeacoffee.com/costinbotez)
+
 ## License
 
 Released under the GPLv2 or later.


### PR DESCRIPTION
## Summary
- reintroduce author section with donation link in README

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498a1cd6348324b3da51898e51d2ff