### PR TITLE
Add search and filter controls to bulk editor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,3 +46,8 @@
     border-radius: 5px;
     z-index: 10000; /* make sure it's above everything else */
 }
+
+.filter-controls input,
+.filter-controls select {
+    padding: 5px;
+}

--- a/js/bulk-meta-editor.js
+++ b/js/bulk-meta-editor.js
@@ -1,6 +1,36 @@
 jQuery(document).ready(function($) {
     var changes = {};
 
+    function filterRows() {
+        var search = $('#search-box').val().toLowerCase();
+        var category = $('#category-filter').val();
+        var type = $('#post-type-filter').val();
+
+        $('#meta_info_table tbody tr').each(function() {
+            var $row = $(this);
+            var title = ($row.data('title') || '').toString();
+            var cats = ($row.data('categories') || '').toString();
+            var postType = ($row.data('post-type') || '').toString();
+
+            var match = true;
+
+            if (search && title.indexOf(search) === -1) {
+                match = false;
+            }
+            if (category && cats.indexOf(category) === -1) {
+                match = false;
+            }
+            if (type && postType !== type) {
+                match = false;
+            }
+
+            $row.toggle(match);
+        });
+    }
+
+    $('#search-box').on('keyup', filterRows);
+    $('#category-filter, #post-type-filter').on('change', filterRows);
+
     $('td.editable').on('click', function() {
         // Prevent clearing existing content if the cell is already being edited
         if ($(this).hasClass('cellEditing')) {

--- a/seo-bulk-meta-editor.php
+++ b/seo-bulk-meta-editor.php
@@ -39,8 +39,23 @@ function yoast_bulk_meta_editor_page()
 {
     // Get all public post types
     $post_types = get_post_types(array('public' => true), 'names');
+    $categories = get_categories(array('hide_empty' => false));
 
     echo '<h1 style="text-align: center;padding: 30px 0">Yoast Bulk Meta Editor</h1>';
+
+    echo '<div class="filter-controls" style="text-align:center;margin-bottom:20px;">';
+    echo '<input type="text" id="search-box" placeholder="Search title..." style="margin-right:10px;" />';
+    echo '<select id="category-filter" style="margin-right:10px;"><option value="">All Categories</option>';
+    foreach ($categories as $cat) {
+        echo '<option value="' . esc_attr($cat->slug) . '">' . esc_html($cat->name) . '</option>';
+    }
+    echo '</select>';
+    echo '<select id="post-type-filter"><option value="">All Post Types</option>';
+    foreach ($post_types as $type) {
+        echo '<option value="' . esc_attr($type) . '">' . esc_html(ucfirst($type)) . '</option>';
+    }
+    echo '</select>';
+    echo '</div>';
 
     echo '<div id="notification" class="toast" style="display: none; text-align: center; padding: 10px;"></div>';
     echo '<table id="meta_info_table" class="wp-list-table widefat fixed striped posts">';
@@ -70,7 +85,19 @@ function yoast_bulk_meta_editor_page()
         // displayed and can be updated properly.
         $post_meta_keywords = get_post_meta($post->ID, '_yoast_wpseo_focuskw', true);
         $post_meta_title = get_post_meta($post->ID, '_yoast_wpseo_title', true);
-        echo '<tr data-post-id="' . $post->ID . '"><td><a href="' . $page_title_link . '">'. $page_title . '</a></td><td>' . ucfirst($post_type) . '</td><td class="editable" data-meta-key="_yoast_wpseo_title">' . $post_meta_title . '</td><td class="editable" data-meta-key="_yoast_wpseo_metadesc">' . $post_meta_description . '</td><td class="editable" data-meta-key="_yoast_wpseo_focuskw">' . $post_meta_keywords . '</td></tr>';
+        $cat_slugs = wp_get_post_terms($post->ID, 'category', array('fields' => 'slugs'));
+        $row  = '<tr data-post-id="' . $post->ID . '"';
+        $row .= ' data-title="' . esc_attr(strtolower($page_title)) . '"';
+        $row .= ' data-categories="' . esc_attr(implode(',', $cat_slugs)) . '"';
+        $row .= ' data-post-type="' . esc_attr($post_type) . '"';
+        $row .= '>'; 
+        $row .= '<td><a href="' . $page_title_link . '">' . $page_title . '</a></td>';
+        $row .= '<td>' . ucfirst($post_type) . '</td>';
+        $row .= '<td class="editable" data-meta-key="_yoast_wpseo_title">' . $post_meta_title . '</td>';
+        $row .= '<td class="editable" data-meta-key="_yoast_wpseo_metadesc">' . $post_meta_description . '</td>';
+        $row .= '<td class="editable" data-meta-key="_yoast_wpseo_focuskw">' . $post_meta_keywords . '</td>';
+        $row .= '</tr>';
+        echo $row;
     }
     echo '</tbody>';
     echo '</table>';


### PR DESCRIPTION
## Summary
- add search box and category/post type filters
- store title, category and type metadata on each row
- implement client-side filtering logic
- minor styling for filters

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5f046f083248765935e6425a680