### PR TITLE
Improve filter dropdown logic

### DIFF
--- a/js/bulk-meta-editor.js
+++ b/js/bulk-meta-editor.js
@@ -30,8 +30,22 @@ jQuery(document).ready(function($) {
         });
     }
 
+    function updateCategoryFilter() {
+        var type = $('#post-type-filter').val();
+        if (type === 'post') {
+            $('#category-filter').prop('disabled', false);
+        } else {
+            $('#category-filter').prop('disabled', true).val('');
+        }
+        filterRows();
+    }
+
     $('#search-box').on('keyup', filterRows);
-    $('#category-filter, #post-type-filter').on('change', filterRows);
+    $('#category-filter').on('change', filterRows);
+    $('#post-type-filter').on('change', updateCategoryFilter);
+
+    // Initialize state on page load
+    updateCategoryFilter();
 
     $(document).on('click', 'td.editable', function() {
         // Prevent clearing existing content if the cell is already being edited

--- a/seo-bulk-meta-editor.php
+++ b/seo-bulk-meta-editor.php
@@ -49,14 +49,14 @@ function yoast_bulk_meta_editor_page()
 
     echo '<div class="filter-controls">';
     echo '<input type="text" id="search-box" placeholder="Search title..." />';
-    echo '<select id="category-filter"><option value="">All Categories</option>';
-    foreach ($categories as $cat) {
-        echo '<option value="' . esc_attr($cat->slug) . '">' . esc_html($cat->name) . '</option>';
-    }
-    echo '</select>';
     echo '<select id="post-type-filter"><option value="">All Post Types</option>';
     foreach ($post_types as $type) {
         echo '<option value="' . esc_attr($type) . '">' . esc_html(ucfirst($type)) . '</option>';
+    }
+    echo '</select>';
+    echo '<select id="category-filter" disabled="disabled"><option value="">All Categories</option>';
+    foreach ($categories as $cat) {
+        echo '<option value="' . esc_attr($cat->slug) . '">' . esc_html($cat->name) . '</option>';
     }
     echo '</select>';
     echo '</div>';


### PR DESCRIPTION
## Summary
- reorder filter controls so Post Type appears before Categories
- disable category filter until `Posts` is chosen

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849aa5ed10c83248822ebd93f588fd4