### PR TITLE
Add character limit counters

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,3 +75,21 @@
     display: block;
     margin: 20px auto;
 }
+
+/* Character counter styling */
+.char-counter {
+    font-size: 12px;
+    margin-top: 4px;
+}
+
+.char-counter.ok {
+    color: #4CAF50;
+}
+
+.char-counter.warning {
+    color: #E09100;
+}
+
+.char-counter.exceeded {
+    color: #f44336;
+}

--- a/js/bulk-meta-editor.js
+++ b/js/bulk-meta-editor.js
@@ -58,8 +58,44 @@ jQuery(document).ready(function($) {
         var metaKey = $(this).data('meta-key');
 
         $(this).addClass('cellEditing');
-        $(this).html('<textarea>' + originalContent + '</textarea>');
-        $(this).children('textarea').focus().one('blur', function() {
+
+        var limit = null;
+        if (metaKey === '_yoast_wpseo_title') {
+            limit = 60;
+        } else if (metaKey === '_yoast_wpseo_metadesc') {
+            limit = 160;
+        }
+
+        var $textarea = $('<textarea>' + originalContent + '</textarea>');
+        var $counter = $('<div class="char-counter"></div>');
+
+        function updateCounter() {
+            if (limit === null) {
+                $counter.text('');
+                return;
+            }
+            var remaining = limit - $textarea.val().length;
+            $counter.removeClass('ok warning exceeded');
+            if (remaining < 0) {
+                $counter.addClass('exceeded');
+                $counter.text(Math.abs(remaining) + ' over limit');
+            } else {
+                if (remaining < 10) {
+                    $counter.addClass('warning');
+                } else {
+                    $counter.addClass('ok');
+                }
+                $counter.text(remaining + ' characters remaining');
+            }
+        }
+
+        $textarea.on('input', updateCounter);
+        updateCounter();
+
+        $(this).html('');
+        $(this).append($textarea).append($counter);
+
+        $textarea.focus().one('blur', function() {
             var newContent = $(this).val();
             var $parent = $(this).parent();
             $parent.text(newContent);


### PR DESCRIPTION
## Summary
- show remaining characters for title and description fields
- colorize counters to warn when limits exceeded

## Testing
- `npm test` *(fails: could not find package.json)*
- `php -l seo-bulk-meta-editor.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849abf2b3fc832480105246e283cfe5