### PR TITLE
Filter post type dropdown by user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated adm
 - Edit meta fields inline and save all changes at once via AJAX
 - Responsive table with "Load More" support for large datasets
 - Choose which post types and table columns are included from the plugin's **Settings** page
+- The post type filter dropdown only lists the post types selected in **Settings**
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be installed and active
 
 ## Installation

--- a/seo-bulk-meta-editor.php
+++ b/seo-bulk-meta-editor.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Yoast SEO Bulk Meta Editor
  * Description: Display & edit all meta titles, descriptions, and keywords from all posts, pages, and custom post types into one dashboard.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Plugin URI: https://nomad-developer.co.uk
  * Author: Nomad Developer
  * Author URI:  https://nomad-developer.co.uk
@@ -62,8 +62,15 @@ function yoast_bulk_meta_editor_page()
 {
     $posts_per_page = YBME_POSTS_PER_PAGE;
     $enabled_columns = ybme_get_enabled_columns();
-    // Get all public post types
-    $post_types = get_post_types(array('public' => true), 'names');
+    // Get public post types and filter based on settings
+    $all_public_types = get_post_types(array('public' => true), 'names');
+    $selected_types = get_option('post_types', ['post', 'page']);
+    $post_types = array();
+    foreach ($selected_types as $type) {
+        if (in_array($type, $all_public_types, true)) {
+            $post_types[] = $type;
+        }
+    }
     // Only include categories that contain posts
     $categories = get_categories(array('hide_empty' => true));
 


### PR DESCRIPTION
## Summary
- filter public post types by the options saved in settings
- bump plugin version to 1.2.1
- document dropdown behaviour in README

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849affb13e083248c42da79f67d7d01