### PR TITLE
Add CSV meta tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Yoast SEO Bulk Meta Editor
 
+## v1.2.1 → v1.3.0
+
 Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated admin page for managing Yoast SEO metadata in bulk. It displays the title, meta description and focus keyword for each post, page and any public custom post type in a sortable table so you can update multiple entries quickly.
 
 ## Features
 
+### Free
 - View all Yoast SEO meta titles, descriptions and keywords in one place
 - Edit meta fields inline and save all changes at once via AJAX
 - Responsive table with "Load More" support for large datasets
 - Choose which post types and table columns are included from the plugin's **Settings** page
 - The post type filter dropdown only lists the post types selected in **Settings**
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be installed and active
+
+### Premium
+- CSV Meta Tools (PRO) for fast import/export of metadata
 
 ## Installation
 

--- a/css/style.css
+++ b/css/style.css
@@ -99,3 +99,15 @@
     margin-top: 20px;
     text-align: left;
 }
+
+.ybme-upsell {
+    border: 2px dashed #ffba00;
+    background: #fffbe5;
+    padding: 15px;
+    margin-top: 20px;
+    text-align: center;
+}
+
+.ybme-upsell-subtext {
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- bump plugin version to 1.3.0
- add license key support and upsell banner
- implement CSV Import/Export PRO tools
- style upsell banner
- document new version and premium features

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b13160648324bde3bbc79d2610cf